### PR TITLE
toast notification functionality for Read Docs and Get Started in Banner component.

### DIFF
--- a/src/renderer/src/components/Banner.tsx
+++ b/src/renderer/src/components/Banner.tsx
@@ -1,25 +1,30 @@
-import { GetStartedButton, ReadDocsButton } from "@/components"
+import { GetStartedButton, ReadDocsButton } from '@/components'
+import { ToastContainer, toast } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
 
 const styles = {
-    banner: "justify-center items-center",
-    btnGroup: "flex gap-x-8 justify-center items-center",
-    bannerText: "w-fit mx-auto mt-48 mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-slate-300 to-slate-500"
+  banner: 'justify-center items-center',
+  btnGroup: 'flex gap-x-8 justify-center items-center',
+  bannerText:
+    'w-fit mx-auto mt-48 mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-slate-300 to-slate-500'
 }
 
 const Banner = () => {
-    return (
-        <div className={styles.banner}>
-            <div>
-                <h3 className={styles.bannerText}>
-                    Local Custom Domains
-                </h3>
-            </div>
-            <div className={styles.btnGroup}>
-                <GetStartedButton />
-                <ReadDocsButton />
-            </div>
+  return (
+    <div className={styles.banner}>
+      <div>
+        <h3 className={styles.bannerText}>Local Custom Domains</h3>
+      </div>
+      <div className={styles.btnGroup}>
+        <GetStartedButton />
+
+        <div onClick={() => toast.info('This feature is under development.')}>
+          <ReadDocsButton />
         </div>
-    )
+        <ToastContainer position="bottom-right" />
+      </div>
+    </div>
+  )
 }
 
 export default Banner

--- a/src/renderer/src/components/Banner.tsx
+++ b/src/renderer/src/components/Banner.tsx
@@ -1,30 +1,40 @@
-import { GetStartedButton, ReadDocsButton } from '@/components'
-import { ToastContainer, toast } from 'react-toastify'
-import 'react-toastify/dist/ReactToastify.css'
+import { GetStartedButton, ReadDocsButton } from '@/components';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 const styles = {
   banner: 'justify-center items-center',
   btnGroup: 'flex gap-x-8 justify-center items-center',
   bannerText:
     'w-fit mx-auto mt-48 mb-12 text-center bg-clip-text text-transparent bg-gradient-to-r from-slate-300 to-slate-500'
-}
+};
 
 const Banner = () => {
+  const showToast = () => {
+    toast.info('This feature is under development.');
+  };
+
   return (
     <div className={styles.banner}>
       <div>
         <h3 className={styles.bannerText}>Local Custom Domains</h3>
       </div>
       <div className={styles.btnGroup}>
-        <GetStartedButton />
 
-        <div onClick={() => toast.info('This feature is under development.')}>
+        <button onClick={showToast}>
+          <GetStartedButton />
+        </button>
+
+        <button onClick={showToast}>
           <ReadDocsButton />
-        </div>
+        </button>
+        
         <ToastContainer position="bottom-right" />
+
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default Banner
+export default Banner;
+


### PR DESCRIPTION
This feature utilizes React Toastify to display a brief notification when the "Read Docs" button is clicked, informing users that the documentation is currently under development.

Here is the screenshoot : 
![Screenshot 2024-10-13 154058](https://github.com/user-attachments/assets/18d131a6-2c1a-48e1-adba-1845e2ba9c25)

Steps to Remove Notification Functionality:

1. Remove the import statements for ToastContainer and toast and its Css.
2. Delete the line.
3. Remove the div wrapping the ReadDocsButton that contains the onClick handler.



